### PR TITLE
improve build server performance by allowing disabling of pre-dexing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: false
+sudo: required
 
 language: android
 
@@ -6,8 +6,6 @@ env:
   global:
     # switch glibc to a memory conserving mode
     - MALLOC_ARENA_MAX=2
-    # wait up to 10 minutes for adb to connect to emulator
-    - ADB_INSTALL_TIMEOUT=10
 
 jdk:
   # the release build infrastructure uses OpenJDK from Debian
@@ -24,23 +22,16 @@ android:
     - extra-android-m2repository
     - build-tools-23.0.2
     - android-23
-#    - sys-img-x86-android-22
+  licenses:
+    # only approve the non-Google licenses
+    - 'android-sdk-preview-license-52d11cd2'
+    - 'android-sdk-license-.+'
 
 cache: false
-# Add this
-sudo: required
 
 script:
   # 'assemble' everything and run all checks that do not require a device/emulator
-  - ./gradlew build
-  # start the emulator after the build to conserve memory
-  #- android list targets
-  #- echo no | android create avd --force -n test -t android-22 --abi x86
-  #- emulator -avd test -no-skin -no-audio -no-window &
-  #- android-wait-for-emulator
-  #- adb shell input keyevent 82 &
-  # now run the tests that require a device/emulator
-  #- ./gradlew connectedCheck
+  - ./gradlew build -PdisablePreDex
 
 after_failure:
   - find * -name lint-results.xml | xargs cat

--- a/build.gradle
+++ b/build.gradle
@@ -25,3 +25,19 @@ allprojects {
         appcompat='com.android.support:appcompat-v7:23.1.0'
     }
 }
+
+/**
+ * Improve build server performance by allowing disabling of pre-dexing
+ * (see http://tools.android.com/tech-docs/new-build-system/tips#TOC-Improving-Build-Server-performance.)
+ */
+project.ext.preDexLibs = !project.hasProperty('disablePreDex')
+
+subprojects {
+  project.plugins.whenPluginAdded { plugin ->
+    if ("com.android.build.gradle.AppPlugin".equals(plugin.class.name)) {
+      project.android.dexOptions.preDexLibraries = rootProject.ext.preDexLibs
+    } else if ("com.android.build.gradle.LibraryPlugin".equals(plugin.class.name)) {
+      project.android.dexOptions.preDexLibraries = rootProject.ext.preDexLibs
+    }
+  }
+}


### PR DESCRIPTION
Google is finally getting involved in CI builds, and they recommend this:
http://tools.android.com/tech-docs/new-build-system/tips#TOC-Improving-Build-Server-performance

This also purges the unused emulator stuff.  You can find working versions of that in NetCipher and other projects.
