### PR TITLE
reproducible build fixes

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -42,6 +42,7 @@ android {
         applicationId 'im.zom.messenger'
         versionCode 1501908
         versionName getVersionName()
+        archivesBaseName = "Zom-$versionName"
         minSdkVersion project.ext.minSdkVersion
         targetSdkVersion project.ext.targetSdkVersion
         testApplicationId 'im.zom.messenger.test'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,6 +16,16 @@ buildscript {
 apply plugin: 'com.android.application'
 apply plugin: 'witness'
 
+/* gets the version name from the latest Git tag, stripping the leading v off */
+def getVersionName = { ->
+    def stdout = new ByteArrayOutputStream()
+    exec {
+        commandLine 'git', 'describe', '--tags', '--always'
+        standardOutput = stdout
+    }
+    return stdout.toString().trim()
+}
+
 android {
 
     compileSdkVersion project.ext.compileSdkVersion
@@ -30,6 +40,8 @@ android {
 
     defaultConfig {
         applicationId 'im.zom.messenger'
+        versionCode 1501908
+        versionName getVersionName()
         minSdkVersion project.ext.minSdkVersion
         targetSdkVersion project.ext.targetSdkVersion
         testApplicationId 'im.zom.messenger.test'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,9 +4,7 @@
     package="im.zom.messenger"
     android:installLocation="auto"
     android:sharedUserLabel="@string/perm_label"
-    android:usesCleartextTraffic="false"
-    android:versionCode="1501908"
-    android:versionName="15.0.1-BETA-8">
+    android:usesCleartextTraffic="false">
 
     <supports-screens
         android:anyDensity="true"


### PR DESCRIPTION
These two automate the procedure of naming a release build APK, so that they are totally standardized and can be automatically parsed by the fdroidserver tools.  See https://gitlab.com/fdroid/fdroiddata/merge_requests/1442
