### PR TITLE
include fdroid metadata for building with `fdroid build`

### DIFF
--- a/.fdroid.yml
+++ b/.fdroid.yml
@@ -1,0 +1,67 @@
+Categories:
+  - Phone & SMS
+  - Security
+License: Apache-2
+Web Site: https://zom.im
+Source Code: https://github.com/zom/zom-android
+Issue Tracker: https://github.com/zom/zom-android/issues
+
+Auto Name: Zom
+Summary: Zom Mobile Messenger
+Description: |
+ Zom is a place where friends can be friends, and you can always speak
+ your mind freely. Free & open-source with privacy features that helps
+ keep you connected, no matter where you are. Once connected on Zom,
+ you can send free text and voice messages, share photos, stickers and
+ more!
+
+ ** Zom is Simple **
+ With Zom, you don't need phone or email registration. Just create a
+ fun username to get started on your Android and iOS devices - and
+ that includes your tablets!
+
+ ** Free & Unlimited Voice Messaging **
+ Sending voice messages on Zom is not just fun, but convenient. Once
+ you start recording, you will never run out of time.
+
+ ** Zom Groups! **
+ Create your own group. Never miss an update from your family and
+ friends. Start exciting conversation and debates and keep them
+ running
+
+ ** Fun & Free Stickers **
+ Zom stickers are unique and can be shared across many apps
+
+ ** Share Files **
+ Zom exports files quickly and easily. When you share a photo in Zom,
+ your friends and family will receive it exactly as you sent it. Zom
+ doesn't compromise quality!
+
+
+Repo Type: git
+Repo: https://github.com/zom/zom-android
+
+builds:
+ - versionName: 15.0.1.930
+   versionCode: 1501930
+   commit: 15.0.1.930
+   gradle: Zomrelease
+   subdir: app
+   submodules: yes
+
+ - versionName: 15.0.1.931
+   versionCode: 1501931
+   commit: 15.0.1.931
+   gradle: Zomrelease
+   subdir: app
+   submodules: yes
+
+ - versionName: 15.0.1.932
+   versionCode: 1501932
+   commit: 15.0.1.932
+   gradle: Zomrelease
+   subdir: app
+   submodules: yes
+
+Auto Update Mode: "Version v%v"
+Update Check Mode: Tags


### PR DESCRIPTION
This is the full metadata required for building this app with the _fdroidserver_ toolchain.  It will plug into the reproducible builds when used with the build server.  It will also allow other fdroid repos to include this source repo by using only these two lines:

    Repo Type:git
    Repo:https://github.com/zom/Zom-Android

Since this currently includes proprietary libs, this has to be built using:

    fdroid build --skip-scan
