### PR TITLE
Disable switches until we have a session

### DIFF
--- a/app/src/main/java/org/awesomeapp/messenger/ui/GroupDisplayActivity.java
+++ b/app/src/main/java/org/awesomeapp/messenger/ui/GroupDisplayActivity.java
@@ -203,22 +203,32 @@ public class GroupDisplayActivity extends BaseActivity implements IChatSessionLi
                         }
                     });*/
 
-                    h.checkNotifications.setChecked(areNotificationsEnabled());
-                    h.checkNotifications.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
-                        @Override
-                        public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
-                            setNotificationsEnabled(isChecked);
-                        }
-                    });
+                    if (mSession != null) {
+                        h.checkNotifications.setChecked(areNotificationsEnabled());
+                        h.checkNotifications.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+                            @Override
+                            public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
+                                setNotificationsEnabled(isChecked);
+                            }
+                        });
+                        h.checkNotifications.setEnabled(true);
+                    } else {
+                        h.checkNotifications.setEnabled(false);
+                    }
 
                     if (Preferences.doGroupEncryption()) {
-                        h.checkGroupEncryption.setChecked(isGroupEncryptionEnabled());
-                        h.checkGroupEncryption.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
-                            @Override
-                            public void onCheckedChanged(CompoundButton compoundButton, boolean isChecked) {
-                                setGroupEncryptionEnabled(isChecked);
+                        if (mSession != null) {
+                            h.checkGroupEncryption.setChecked(isGroupEncryptionEnabled());
+                            h.checkGroupEncryption.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+                                @Override
+                                public void onCheckedChanged(CompoundButton compoundButton, boolean isChecked) {
+                                    setGroupEncryptionEnabled(isChecked);
                                 }
-                        });
+                            });
+                            h.checkGroupEncryption.setEnabled(true);
+                        } else {
+                            h.checkGroupEncryption.setEnabled(false);
+                        }
                     }
                     else {
                         h.actionGroupEncryption.setVisibility(View.GONE);
@@ -354,6 +364,11 @@ public class GroupDisplayActivity extends BaseActivity implements IChatSessionLi
                         }
                     }
                     updateMembers();
+
+                    // Update recycler view adapter (if set) to enable session dependent stuff, like notifications
+                    if (mRecyclerView != null) {
+                        mRecyclerView.getAdapter().notifyDataSetChanged();
+                    }
                 }
             }
         }


### PR DESCRIPTION
Couldn't really find a reason why encryption setting would not be persisted, unless you entered the group activity without a session and immediately toggled the switch. In that case the switch would appear as "on" but nothing would be persisted because session == null. Added a check to disable the switch(es) until we have a valid session. I don't know if this really was the problem?